### PR TITLE
Test vectors for `did:web` resolution

### DIFF
--- a/web5-test-vectors/did-web/resolve.json
+++ b/web5-test-vectors/did-web/resolve.json
@@ -12,6 +12,7 @@
         }
       },
       "output": {
+        "didResolutionMetadata": {},
         "didDocument": {
           "id": "did:web:example.com"
         }
@@ -29,6 +30,7 @@
         }
       },
       "output": {
+        "didResolutionMetadata": {},
         "didDocument": {
           "id": "did:web:w3c-ccg.github.io:user:alice"
         }
@@ -46,6 +48,7 @@
         }
       },
       "output": {
+        "didResolutionMetadata": {},
         "didDocument": {
           "id": "did:web:example.com%3A3000:user:alice"
         }

--- a/web5-test-vectors/did-web/resolve.json
+++ b/web5-test-vectors/did-web/resolve.json
@@ -1,0 +1,56 @@
+{
+  "description": "did:web resolution",
+  "vectors": [
+    {
+      "description": "resolves to a well known URL",
+      "input": {
+        "didUri": "did:web:example.com",
+        "mockServer": {
+          "https://example.com/.well-known/did.json": {
+            "id": "did:web:example.com"
+          }
+        }
+      },
+      "output": {
+        "didDocument": {
+          "id": "did:web:example.com"
+        }
+      },
+      "result": "valid"
+    },
+    {
+      "description": "resolves to a URL with a path",
+      "input": {
+        "didUri": "did:web:w3c-ccg.github.io:user:alice",
+        "mockServer": {
+          "https://w3c-ccg.github.io/user/alice/did.json": {
+            "id": "did:web:w3c-ccg.github.io:user:alice"
+          }
+        }
+      },
+      "output": {
+        "didDocument": {
+          "id": "did:web:w3c-ccg.github.io:user:alice"
+        }
+      },
+      "result": "valid"
+    },
+    {
+      "description": "resolves to a URL with a path and a port",
+      "input": {
+        "didUri": "did:web:example.com%3A3000:user:alice",
+        "mockServer": {
+          "https://example.com:3000/user/alice/did.json": {
+            "id": "did:web:example.com%3A3000:user:alice"
+          }
+        }
+      },
+      "output": {
+        "didDocument": {
+          "id": "did:web:example.com%3A3000:user:alice"
+        }
+      },
+      "result": "valid"
+    }
+  ]
+}

--- a/web5-test-vectors/index.html
+++ b/web5-test-vectors/index.html
@@ -28,6 +28,8 @@
             <ul>
                 <li><a class="did-jwk-resolve" href="https://DOMAIN.NAME/did-jwk/resolve.json" class="href">did:jwk resolve</a>
                 </li>
+                <li><a class="did-web-resolve" href="https://DOMAIN.NAME/did-web/resolve.json" class="href">did:web resolve</a>
+                </li>
             </ul>
         </div>
 


### PR DESCRIPTION
This PR fixes #15 by adding `did:web` test vectors. It build's on top of #66, so will wait until that is merged. 

One noteworthy piece is that I included mocking instructions here in the test vectors, since they are critical for `did:web` resolution.