### PR TITLE
Update feature regex + fix gh pages publishing

### DIFF
--- a/.github/workflows/build-report.yaml
+++ b/.github/workflows/build-report.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
   build-report:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pages: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -19,5 +23,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-pages-artifact@v2
       - name: deploy GitHub Pages
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3
         if: github.ref == 'refs/heads/main'

--- a/reports/sdks.go
+++ b/reports/sdks.go
@@ -21,14 +21,14 @@ var (
 			Name:         "web5-js",
 			Repo:         "TBD54566975/web5-js",
 			ArtifactName: "junit-results",
-			FeatureRegex: regexp.MustCompile(`Web5TestVectors(\w+)Spec`),
+			FeatureRegex: regexp.MustCompile(`Web5TestVectors(\w+)`),
 			VectorRegex:  regexp.MustCompile(`\w+ \w+ (\w+)`),
 		},
 		{
 			Name:         "web5-kt",
 			Repo:         "TBD54566975/web5-kt",
 			ArtifactName: "test-results",
-			FeatureRegex: regexp.MustCompile(`web5\.sdk\.\w+.Web5TestVectors(\w+)Test`),
+			FeatureRegex: regexp.MustCompile(`web5\.sdk\.\w+.Web5TestVectors(\w+)`),
 			VectorRegex:  regexp.MustCompile(`(\w+)\(\)`),
 		},
 	}


### PR DESCRIPTION
As decided in the meeting on Thursday, this drops the `Spec` and `Test` suffix from the web5-js and web5-kt expected output. web5-kt has already done this, web5-js is expected to follow soon.

it also fixes permission issues with github pages publishing that cropped up when publishing was merged to main