### PR TITLE
skip artifacts from non-main branches

### DIFF
--- a/reports/sdks.go
+++ b/reports/sdks.go
@@ -76,6 +76,9 @@ func downloadArtifact(ctx context.Context, sdk SDKMeta) ([]byte, error) {
 
 	var artifactURL string
 	for _, a := range artifacts.Artifacts {
+		if a.GetWorkflowRun().GetHeadBranch() != "main" {
+			continue
+		}
 		if *a.Name == sdk.ArtifactName {
 			artifactURL = *a.ArchiveDownloadURL
 			slog.Info("downloading artifact", "repo", sdk.Repo, "commit", a.GetWorkflowRun().GetHeadSHA())


### PR DESCRIPTION
This addresses a bug in the current implementation of the report generator that causes it to download the latest artifact, regardless of branch.