### PR TITLE
show entries for all vectors

### DIFF
--- a/reports/reports.go
+++ b/reports/reports.go
@@ -14,7 +14,7 @@ import (
 var (
 	ErrNotSupported = errors.New("test not supported by this SDK")
 
-	//go:embed *
+	//go:embed report-template.html
 	templatesFS embed.FS
 
 	htmlTemplates = htmltemplate.New("")
@@ -84,6 +84,14 @@ func (r Result) GetEmoji() string {
 
 func (s SDKMeta) buildReport(suites []junit.Suite) (Report, error) {
 	results := make(map[string]map[string]Result)
+
+	for feature, vectors := range knownVectors {
+		results[feature] = make(map[string]Result)
+		for vector := range vectors {
+			results[feature][vector] = Result{}
+		}
+	}
+
 	for _, suite := range suites {
 		suiteName := suite.Name
 		if s.FeatureRegex != nil {


### PR DESCRIPTION
previous behavior ignored vectors with no corresponding tests. expected result:

![image](https://github.com/TBD54566975/sdk-development/assets/139806439/19e7edd7-ab9b-435e-a56e-6f0d0074a621)
