### PR TITLE
fix a bug causing known vectors with no implementations to disappear from the final report in some cases

### DIFF
--- a/reports/reports.go
+++ b/reports/reports.go
@@ -109,8 +109,6 @@ func (s SDKMeta) buildReport(suites []junit.Suite) (Report, error) {
 			continue
 		}
 
-		results[suiteName] = make(map[string]Result)
-
 		for _, test := range suite.Tests {
 			testName := test.Name
 			if s.VectorRegex != nil {


### PR DESCRIPTION
specifically triggered when there are some implemented vectors in the feature, previously causing the test suite parser to rebuild the map for that feature