### PR TITLE
Add empty `didDocumentMetadata` to each did_web test vector

### DIFF
--- a/web5-test-vectors/did_web/resolve.json
+++ b/web5-test-vectors/did_web/resolve.json
@@ -15,7 +15,8 @@
         "didResolutionMetadata": {},
         "didDocument": {
           "id": "did:web:example.com"
-        }
+        },
+        "didDocumentMetadata": {}
       }
     },
     {
@@ -32,7 +33,8 @@
         "didResolutionMetadata": {},
         "didDocument": {
           "id": "did:web:w3c-ccg.github.io:user:alice"
-        }
+        },
+        "didDocumentMetadata": {}
       }
     },
     {
@@ -49,7 +51,8 @@
         "didResolutionMetadata": {},
         "didDocument": {
           "id": "did:web:example.com%3A3000:user:alice"
-        }
+        },
+        "didDocumentMetadata": {}
       }
     },
     {
@@ -60,7 +63,8 @@
       "output": {
         "didResolutionMetadata": {
           "error": "methodNotSupported"
-        }
+        },
+        "didDocumentMetadata": {}
       },
       "errors": true
     },
@@ -72,7 +76,8 @@
       "output": {
         "didResolutionMetadata": {
           "error": "notFound"
-        }
+        },
+        "didDocumentMetadata": {}
       },
       "errors": true
     },
@@ -84,7 +89,8 @@
       "output": {
         "didResolutionMetadata": {
           "error": "invalidDid"
-        }
+        },
+        "didDocumentMetadata": {}
       },
       "errors": true
     }


### PR DESCRIPTION
According to the [`did_web` README](https://github.com/TBD54566975/sdk-development/tree/main/web5-test-vectors/did_web), each vector should have an empty `didDocumentMetadata`. 

This PR adds this requirement to each vector's output.