### PR TITLE
Allow authenticating to GitHub with a Personal Access Token

### DIFF
--- a/reports/README.md
+++ b/reports/README.md
@@ -2,7 +2,15 @@
 
 This tool reads junit XML reports from different SDKs and generates an HTML report showing which SDKs support which features.
 
-## Current Status
-
 `./cmd/build-html` will iterate over the repos listed in `sdk.go` and download the most recent junit artifact. It will read
-all junit results from it and produce a report to `_site/index.html`
+all junit results from it and produce a report to `_site/index.html`.  For local testing, generate a
+[GitHub Personal Access Token](https://github.com/settings/tokens?type=beta) and put it in an environment variable named
+`GITHUB_TOKEN`. It doesn't need any special permissions ("Public Repositories (read-only)"). Note that a GitHub app (explained below) can also be used.
+
+`./cmd/sync-vectors` will check the `main` branch of all SDKs listed in `sdks.go` and ensure their vectors match the ones in this repo.
+For local testing, a [GitHub App](https://github.com/settings/apps) must be created. Put it's credentials in the following environment variables:
+
+* `CICD_ROBOT_GITHUB_APP_ID` - shown on the edit page of the app, where you are sent right after app creation.
+* `CICD_ROBOT_GITHUB_APP_PRIVATE_KEY` - this should be the contents of the private key, not the path to the file.
+* `CICD_ROBOT_GITHUB_APP_NAME` - this is used as a display name and should match the name in the URL of the edit page for the app.
+* `CICD_ROBOT_GITHUB_APP_INSTALLATION_ID` - click "Install App" on the sidebar while editing the app in GitHub to install it on your own account.

--- a/reports/github.go
+++ b/reports/github.go
@@ -18,6 +18,8 @@ var (
 	ghAppIDString             = os.Getenv("CICD_ROBOT_GITHUB_APP_ID")
 	ghAppInstallationIDString = os.Getenv("CICD_ROBOT_GITHUB_APP_INSTALLATION_ID")
 
+	ghToken = os.Getenv("GITHUB_TOKEN")
+
 	gh          *github.Client
 	ghTransport *ghinstallation.Transport
 
@@ -25,6 +27,12 @@ var (
 )
 
 func init() {
+	if ghToken != "" {
+		slog.Info("using GITHUB_TOKEN for auth")
+		gh = github.NewTokenClient(context.Background(), ghToken)
+		return
+	}
+
 	ghAppID, err := strconv.ParseInt(ghAppIDString, 10, 32)
 	if err != nil {
 		slog.Error("invalid or unset app ID. Please set environment variable CICD_ROBOT_GITHUB_APP_ID to a valid integer")

--- a/reports/sdks.go
+++ b/reports/sdks.go
@@ -82,9 +82,12 @@ func downloadArtifact(ctx context.Context, sdk SDKMeta) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	bearer, err := ghTransport.Token(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error getting github token: %v", err)
+	bearer := ghToken
+	if ghToken == "" {
+		bearer, err = ghTransport.Token(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error getting github token: %v", err)
+		}
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", bearer))
 	resp, err := http.DefaultClient.Do(req)

--- a/reports/sync.go
+++ b/reports/sync.go
@@ -200,6 +200,9 @@ func ConfigureGitAuth() error {
 	}
 	gitCredentialStoreFile = f.Name()
 
+	if ghTransport == nil {
+		panic("syncing vecotrs with a PAT not supported. See reports/README.md for instructions to create a GitHub app.")
+	}
 	authToken, err := ghTransport.Token(context.Background())
 	if err != nil {
 		slog.Error("error getting github auth token")


### PR DESCRIPTION
this will make it easier to test local changes to the report generator without having to create a whole GitHub app.