### PR TITLE
Add Ed25519 sign and verify test vectors

### DIFF
--- a/web5-test-vectors/README.md
+++ b/web5-test-vectors/README.md
@@ -7,7 +7,7 @@ This directory contains test vectors for all features we intend to support accro
 ```text
 web5-test-vectors
 ├── README.md
-├── did-jwk <--- feature
+├── did_jwk <--- feature
 │   └── resolve.json <--- sub-feature
 ├── index.html
 └── vectors.schema.json
@@ -65,7 +65,7 @@ Should `errors` be set to `true`, the `output` field may optionally be used to i
       "description": "this is an example",
       "input": "hello world",
       "output": "hello world",
-      "errors" : false
+      "errors": false
     }
   ]
 }

--- a/web5-test-vectors/crypto_ed25519/README.md
+++ b/web5-test-vectors/crypto_ed25519/README.md
@@ -1,0 +1,58 @@
+# `Ed25519` Test Vectors
+
+This directory contains test vectors for the `Ed25519` signature scheme, which is a part of the
+Edwards-curve Digital Signature Algorithm (EdDSA) family of signature algorithms as detailed in
+[RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032).
+
+## `sign`
+
+Sign test vectors are detailed in a [JSON file](./sign.json). It includes cases for testing the
+signing operation with the Ed25519 curve.
+
+### Input
+
+The `input` for the sign operation is an object with the following properties:
+
+| Property | Description                                                          |
+| -------- | -------------------------------------------------------------------- |
+| `key`    | A JSON Web Key ([JWK][RFC7517]) object representing the private key. |
+| `data`   | The data to be signed, as a byte array in hexadecimal string format. |
+
+### Output
+
+The `output` is a hexadecimal string representing the signature byte array produced by the signing
+operation.
+
+### Reference Implementations
+
+Reference implementations for the sign operation can be found in the following SDK repositories:
+
+- TypeScript: [`Ed25519.sign()`](https://github.com/TBD54566975/web5-js/blob/44c38a116dec0b357ca15d807eb513f819341e50/packages/crypto/src/primitives/ed25519.ts#L434-L468)
+
+## `verify`
+
+Verify test vectors are outlined in a [JSON file](./verify.json), encompassing both successful and unsuccessful signature verification cases.
+
+### Input
+
+The `input` for the verify operation includes:
+
+| Property    | Description                                                                      |
+| ----------- | -------------------------------------------------------------------------------- |
+| `key`       | An JSON Web Key ([JWK][RFC7517]) object representing the public key.             |
+| `signature` | The signature to verify, as a byte array in hexadecimal string format.           |
+| `data`      | The original data that was signed, as a byte array in hexadecimal string format. |
+
+### Output
+
+The `output` is a boolean value indicating whether the signature verification was successful
+(`true`) or not (`false`).
+
+### Reference Implementations
+
+Reference implementations for the verify operation can also be found in the following SDK
+repositories:
+
+- TypeScript: [`Ed25519.verify()`](https://github.com/TBD54566975/web5-js/blob/44c38a116dec0b357ca15d807eb513f819341e50/packages/crypto/src/primitives/ed25519.ts#L512-L547)
+
+[RFC7517]: https://datatracker.ietf.org/doc/html/rfc7517

--- a/web5-test-vectors/crypto_ed25519/sign.json
+++ b/web5-test-vectors/crypto_ed25519/sign.json
@@ -1,0 +1,65 @@
+{
+  "description": "Ed25519 sign test vectors",
+  "vectors": [
+    {
+      "description": "generates the expected signature given the RFC8032 0x9d... key and empty message",
+      "input": {
+        "data": "",
+        "key": {
+          "crv": "Ed25519",
+          "d": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
+          "kid": "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k",
+          "kty": "OKP",
+          "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+        }
+      },
+      "output": "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+      "errors": false
+    },
+    {
+      "description": "generates the expected signature given the RFC8032 0x4c... key and 72 message",
+      "input": {
+        "data": "72",
+        "key": {
+          "crv": "Ed25519",
+          "d": "TM0Imyj_ltqdtsNG7BFOD1uKMZ81q6Yk2oz27U-4pvs",
+          "kid": "FtIu-VbGrfe_KB6CH7GNwODB72MNxj_ml11dEvO-7kk",
+          "kty": "OKP",
+          "x": "PUAXw-hDiVqStwqnTRt-vJyYLM8uxJaMwM1V8Sr0Zgw"
+        }
+      },
+      "output": "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00",
+      "errors": false
+    },
+    {
+      "description": "generates the expected signature given the RFC8032 0x00... key and 5a... message",
+      "input": {
+        "data": "5ac1dfc324f43e6cb79a87ab0470fa857b51fb944982e19074ca44b1e40082c1d07b92efa7ea55ad42b7c027e0b9e33756d95a2c1796a7c2066811dc41858377d4b835c1688d638884cd2ad8970b74c1a54aadd27064163928a77988b24403aa85af82ceab6b728e554761af7175aeb99215b7421e4474c04d213e01ff03e3529b11077cdf28964b8c49c5649e3a46fa0a09dcd59dcad58b9b922a83210acd5e65065531400234f5e40cddcf9804968e3e9ac6f5c44af65001e158067fc3a660502d13fa8874fa93332138d9606bc41b4cee7edc39d753dae12a873941bb357f7e92a4498847d6605456cb8c0b425a47d7d3ca37e54e903a41e6450a35ebe5237c6f0c1bbbc1fd71fb7cd893d189850295c199b7d88af26bc8548975fda1099ffefee42a52f3428ddff35e0173d3339562507ac5d2c45bbd2c19cfe89b",
+        "key": {
+          "crv": "Ed25519",
+          "d": "AC_dH3ZBeTqwZLt6qEj3YufsbjMv_CburNoUGuM7F4M",
+          "kid": "M7TyrCUM12xZUUArpFOvdxvSN0CKasiRsxOIlVcyEaA",
+          "kty": "OKP",
+          "x": "d9HY66zRP04vikDijEpjvJzjv7aXFjNLyyijPrE0CGw"
+        }
+      },
+      "output": "0df3aa0d0999ad3dc580378f52d152700d5b3b057f56a66f92112e441e1cb9123c66f18712c87efe22d2573777296241216904d7cdd7d5ea433928bd2872fa0c",
+      "errors": false
+    },
+    {
+      "description": "generates the expected signature given the RFC8032 0xf5... key and long message",
+      "input": {
+        "data": "08b8b2b733424243760fe426a4b54908632110a66c2f6591eabd3345e3e4eb98fa6e264bf09efe12ee50f8f54e9f77b1e355f6c50544e23fb1433ddf73be84d879de7c0046dc4996d9e773f4bc9efe5738829adb26c81b37c93a1b270b20329d658675fc6ea534e0810a4432826bf58c941efb65d57a338bbd2e26640f89ffbc1a858efcb8550ee3a5e1998bd177e93a7363c344fe6b199ee5d02e82d522c4feba15452f80288a821a579116ec6dad2b3b310da903401aa62100ab5d1a36553e06203b33890cc9b832f79ef80560ccb9a39ce767967ed628c6ad573cb116dbefefd75499da96bd68a8a97b928a8bbc103b6621fcde2beca1231d206be6cd9ec7aff6f6c94fcd7204ed3455c68c83f4a41da4af2b74ef5c53f1d8ac70bdcb7ed185ce81bd84359d44254d95629e9855a94a7c1958d1f8ada5d0532ed8a5aa3fb2d17ba70eb6248e594e1a2297acbbb39d502f1a8c6eb6f1ce22b3de1a1f40cc24554119a831a9aad6079cad88425de6bde1a9187ebb6092cf67bf2b13fd65f27088d78b7e883c8759d2c4f5c65adb7553878ad575f9fad878e80a0c9ba63bcbcc2732e69485bbc9c90bfbd62481d9089beccf80cfe2df16a2cf65bd92dd597b0707e0917af48bbb75fed413d238f5555a7a569d80c3414a8d0859dc65a46128bab27af87a71314f318c782b23ebfe808b82b0ce26401d2e22f04d83d1255dc51addd3b75a2b1ae0784504df543af8969be3ea7082ff7fc9888c144da2af58429ec96031dbcad3dad9af0dcbaaaf268cb8fcffead94f3c7ca495e056a9b47acdb751fb73e666c6c655ade8297297d07ad1ba5e43f1bca32301651339e22904cc8c42f58c30c04aafdb038dda0847dd988dcda6f3bfd15c4b4c4525004aa06eeff8ca61783aacec57fb3d1f92b0fe2fd1a85f6724517b65e614ad6808d6f6ee34dff7310fdc82aebfd904b01e1dc54b2927094b2db68d6f903b68401adebf5a7e08d78ff4ef5d63653a65040cf9bfd4aca7984a74d37145986780fc0b16ac451649de6188a7dbdf191f64b5fc5e2ab47b57f7f7276cd419c17a3ca8e1b939ae49e488acba6b965610b5480109c8b17b80e1b7b750dfc7598d5d5011fd2dcc5600a32ef5b52a1ecc820e308aa342721aac0943bf6686b64b2579376504ccc493d97e6aed3fb0f9cd71a43dd497f01f17c0e2cb3797aa2a2f256656168e6c496afc5fb93246f6b1116398a346f1a641f3b041e989f7914f90cc2c7fff357876e506b50d334ba77c225bc307ba537152f3f1610e4eafe595f6d9d90d11faa933a15ef1369546868a7f3a45a96768d40fd9d03412c091c6315cf4fde7cb68606937380db2eaaa707b4c4185c32eddcdd306705e4dc1ffc872eeee475a64dfac86aba41c0618983f8741c5ef68d3a101e8a3b8cac60c905c15fc910840b94c00a0b9d0",
+        "key": {
+          "crv": "Ed25519",
+          "d": "9eV2fPFTMZUXYw8iaHa4bIFgzFg7wBN0TGvyVfXMDuU",
+          "kty": "OKP",
+          "x": "J4EX_BRMcjQPZ9DyMW6Dhs7_vyskKMnFH-98WX8dQm4",
+          "kid": "lZI1vM7tnlYapaF5-cy86ptx0tT_8Av721hhiNB5ti4"
+        }
+      },
+      "output": "0aab4c900501b3e24d7cdf4663326a3a87df5e4843b2cbdb67cbf6e460fec350aa5371b1508f9f4528ecea23c436d94b5e8fcd4f681e30a6ac00a9704a188a03",
+      "errors": false
+    }
+  ]
+}

--- a/web5-test-vectors/crypto_ed25519/sign.json
+++ b/web5-test-vectors/crypto_ed25519/sign.json
@@ -60,6 +60,19 @@
       },
       "output": "0aab4c900501b3e24d7cdf4663326a3a87df5e4843b2cbdb67cbf6e460fec350aa5371b1508f9f4528ecea23c436d94b5e8fcd4f681e30a6ac00a9704a188a03",
       "errors": false
+    },
+    {
+      "description": "error when given a public key",
+      "input": {
+        "data": "",
+        "key": {
+          "crv": "Ed25519",
+          "kid": "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k",
+          "kty": "OKP",
+          "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+        }
+      },
+      "errors": true
     }
   ]
 }

--- a/web5-test-vectors/crypto_ed25519/verify.json
+++ b/web5-test-vectors/crypto_ed25519/verify.json
@@ -1,0 +1,110 @@
+{
+  "description": "Ed25519 verify test vectors",
+  "vectors": [
+    {
+      "description": "verifies the signature for the RFC8032 0x9d... key and empty message",
+      "input": {
+        "data": "",
+        "key": {
+          "crv": "Ed25519",
+          "kid": "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k",
+          "kty": "OKP",
+          "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+        },
+        "signature": "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b"
+      },
+      "output": true,
+      "errors": false
+    },
+    {
+      "description": "verifies the signature for the RFC8032 0x4c... key and 72 message",
+      "input": {
+        "data": "72",
+        "key": {
+          "crv": "Ed25519",
+          "kid": "FtIu-VbGrfe_KB6CH7GNwODB72MNxj_ml11dEvO-7kk",
+          "kty": "OKP",
+          "x": "PUAXw-hDiVqStwqnTRt-vJyYLM8uxJaMwM1V8Sr0Zgw"
+        },
+        "signature": "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00"
+      },
+      "output": true,
+      "errors": false
+    },
+    {
+      "description": "verifies the signature for the RFC8032 0x00... key and 5a... message",
+      "input": {
+        "data": "5ac1dfc324f43e6cb79a87ab0470fa857b51fb944982e19074ca44b1e40082c1d07b92efa7ea55ad42b7c027e0b9e33756d95a2c1796a7c2066811dc41858377d4b835c1688d638884cd2ad8970b74c1a54aadd27064163928a77988b24403aa85af82ceab6b728e554761af7175aeb99215b7421e4474c04d213e01ff03e3529b11077cdf28964b8c49c5649e3a46fa0a09dcd59dcad58b9b922a83210acd5e65065531400234f5e40cddcf9804968e3e9ac6f5c44af65001e158067fc3a660502d13fa8874fa93332138d9606bc41b4cee7edc39d753dae12a873941bb357f7e92a4498847d6605456cb8c0b425a47d7d3ca37e54e903a41e6450a35ebe5237c6f0c1bbbc1fd71fb7cd893d189850295c199b7d88af26bc8548975fda1099ffefee42a52f3428ddff35e0173d3339562507ac5d2c45bbd2c19cfe89b",
+        "key": {
+          "crv": "Ed25519",
+          "kid": "M7TyrCUM12xZUUArpFOvdxvSN0CKasiRsxOIlVcyEaA",
+          "kty": "OKP",
+          "x": "d9HY66zRP04vikDijEpjvJzjv7aXFjNLyyijPrE0CGw"
+        },
+        "signature": "0df3aa0d0999ad3dc580378f52d152700d5b3b057f56a66f92112e441e1cb9123c66f18712c87efe22d2573777296241216904d7cdd7d5ea433928bd2872fa0c"
+      },
+      "output": true,
+      "errors": false
+    },
+    {
+      "description": "verifies the signature for the RFC8032 0xf5... key and long message",
+      "input": {
+        "data": "08b8b2b733424243760fe426a4b54908632110a66c2f6591eabd3345e3e4eb98fa6e264bf09efe12ee50f8f54e9f77b1e355f6c50544e23fb1433ddf73be84d879de7c0046dc4996d9e773f4bc9efe5738829adb26c81b37c93a1b270b20329d658675fc6ea534e0810a4432826bf58c941efb65d57a338bbd2e26640f89ffbc1a858efcb8550ee3a5e1998bd177e93a7363c344fe6b199ee5d02e82d522c4feba15452f80288a821a579116ec6dad2b3b310da903401aa62100ab5d1a36553e06203b33890cc9b832f79ef80560ccb9a39ce767967ed628c6ad573cb116dbefefd75499da96bd68a8a97b928a8bbc103b6621fcde2beca1231d206be6cd9ec7aff6f6c94fcd7204ed3455c68c83f4a41da4af2b74ef5c53f1d8ac70bdcb7ed185ce81bd84359d44254d95629e9855a94a7c1958d1f8ada5d0532ed8a5aa3fb2d17ba70eb6248e594e1a2297acbbb39d502f1a8c6eb6f1ce22b3de1a1f40cc24554119a831a9aad6079cad88425de6bde1a9187ebb6092cf67bf2b13fd65f27088d78b7e883c8759d2c4f5c65adb7553878ad575f9fad878e80a0c9ba63bcbcc2732e69485bbc9c90bfbd62481d9089beccf80cfe2df16a2cf65bd92dd597b0707e0917af48bbb75fed413d238f5555a7a569d80c3414a8d0859dc65a46128bab27af87a71314f318c782b23ebfe808b82b0ce26401d2e22f04d83d1255dc51addd3b75a2b1ae0784504df543af8969be3ea7082ff7fc9888c144da2af58429ec96031dbcad3dad9af0dcbaaaf268cb8fcffead94f3c7ca495e056a9b47acdb751fb73e666c6c655ade8297297d07ad1ba5e43f1bca32301651339e22904cc8c42f58c30c04aafdb038dda0847dd988dcda6f3bfd15c4b4c4525004aa06eeff8ca61783aacec57fb3d1f92b0fe2fd1a85f6724517b65e614ad6808d6f6ee34dff7310fdc82aebfd904b01e1dc54b2927094b2db68d6f903b68401adebf5a7e08d78ff4ef5d63653a65040cf9bfd4aca7984a74d37145986780fc0b16ac451649de6188a7dbdf191f64b5fc5e2ab47b57f7f7276cd419c17a3ca8e1b939ae49e488acba6b965610b5480109c8b17b80e1b7b750dfc7598d5d5011fd2dcc5600a32ef5b52a1ecc820e308aa342721aac0943bf6686b64b2579376504ccc493d97e6aed3fb0f9cd71a43dd497f01f17c0e2cb3797aa2a2f256656168e6c496afc5fb93246f6b1116398a346f1a641f3b041e989f7914f90cc2c7fff357876e506b50d334ba77c225bc307ba537152f3f1610e4eafe595f6d9d90d11faa933a15ef1369546868a7f3a45a96768d40fd9d03412c091c6315cf4fde7cb68606937380db2eaaa707b4c4185c32eddcdd306705e4dc1ffc872eeee475a64dfac86aba41c0618983f8741c5ef68d3a101e8a3b8cac60c905c15fc910840b94c00a0b9d0",
+        "key": {
+          "crv": "Ed25519",
+          "kty": "OKP",
+          "x": "J4EX_BRMcjQPZ9DyMW6Dhs7_vyskKMnFH-98WX8dQm4",
+          "kid": "lZI1vM7tnlYapaF5-cy86ptx0tT_8Av721hhiNB5ti4"
+        },
+        "signature": "0aab4c900501b3e24d7cdf4663326a3a87df5e4843b2cbdb67cbf6e460fec350aa5371b1508f9f4528ecea23c436d94b5e8fcd4f681e30a6ac00a9704a188a03"
+      },
+      "output": true,
+      "errors": false
+    },
+    {
+      "description": "verification fails if the data was tampered with",
+      "input": {
+        "data": "0002030405060708",
+        "key": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "XVXPU41VtJuEN0m1WTB-9-AqmIr4shYrsycDu05WmRs",
+          "kid": "QVq_liaHGqnWD1xzm3VCmZG7ibO_aZSEK7gZ4I9rEok"
+        },
+        "signature": "6a38583c45ffa51c99cf621fd19219fcc80c39bfa64fba884b27ed90ca46bd4122d8c5c6c87b6757787716c37497948204aae42442023765e9c0bc70e3e7a600"
+      },
+      "output": false,
+      "errors": false
+    },
+    {
+      "description": "verification fails if the signature was tampered with",
+      "input": {
+        "data": "0102030405060708",
+        "key": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "5bXaMJzFcrB8638un6ccrzTQ3Mh-49mPZT9yN10FZJ8",
+          "kid": "_6WIXMTzaw5V0JTPQCluQF58MREJeBSVLCmG7EVCorE"
+        },
+        "signature": "7b7f4334f3df755dc2085dbc9be69588f4e86289c5be22b860f09ee354e5368724c9d96895d20c1b7cf8b723f0191073e0cf9b7d90c0a88fcfbbcdbe8a2df108"
+      },
+      "output": false,
+      "errors": false
+    },
+    {
+      "description": "verification fails if the public key is not associated with the signing key",
+      "input": {
+        "data": "0102030405060708",
+        "key": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "Q7SbAMR1c3ZefhGMU1cSsyfVqSQ4JFShScvO4C4WleY",
+          "kid": "SSMbPCacyDpbL3emWwOY5ESkBpkgtzw4dseWZcFfqjc"
+        },
+        "signature": "50b20a14a64942d3211621c1b8be110f0f5a35b3ff4da123ab2c2d38e98f24548e0727539d0a98cf653b7c4e7732b103ebc5ee0456acf4a601285c6ecedf8e0b"
+      },
+      "output": false,
+      "errors": false
+    }
+  ]
+}

--- a/web5-test-vectors/crypto_ed25519/verify.json
+++ b/web5-test-vectors/crypto_ed25519/verify.json
@@ -105,6 +105,21 @@
       },
       "output": false,
       "errors": false
+    },
+    {
+      "description": "error when given a private key",
+      "input": {
+        "data": "",
+        "key": {
+          "crv": "Ed25519",
+          "d": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
+          "kid": "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k",
+          "kty": "OKP",
+          "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+        },
+        "signature": "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b"
+      },
+      "errors": true
     }
   ]
 }


### PR DESCRIPTION
This PR will:
- Add test vectors for Crypto - Ed25519 - `sign` and `verify` operations
- Test vectors extracted from `web5-js`, where they are currently being used.
- README includes a link to reference implementations of the functions being tested so that other SDK implementers can re-implement in other languages.

closes #85 